### PR TITLE
Fix null-safety error

### DIFF
--- a/lib/models/system_window_body.dart
+++ b/lib/models/system_window_body.dart
@@ -16,7 +16,7 @@ class SystemWindowBody {
     final Map<String, dynamic> map = <String, dynamic>{
       'rows': (rows == null)
           ? null
-          : List<dynamic>.from(rows!.map((x) => x?.getMap())),
+          : List<dynamic>.from(rows!.map((x) => x.getMap())),
       'padding': padding?.getMap(),
       'decoration': decoration?.getMap()
     };
@@ -38,7 +38,7 @@ class EachRow {
     final Map<String, dynamic> map = <String, dynamic>{
       'columns': (columns == null)
           ? null
-          : List<dynamic>.from(columns!.map((x) => x?.getMap())),
+          : List<dynamic>.from(columns!.map((x) => x.getMap())),
       'padding': padding?.getMap(),
       'margin': margin?.getMap(),
       'gravity': Commons.getContentGravity(gravity),

--- a/lib/system_alert_window.dart
+++ b/lib/system_alert_window.dart
@@ -63,8 +63,8 @@ class SystemAlertWindow {
             }
           }
       }
-      return null;
-    } as Future<dynamic> Function(MethodCall)?);
+      return Future(() => false);
+    });
     await _channel.invokeMethod("registerCallBackHandler", <dynamic>[callBackDispatcher.toRawHandle(), callBack.toRawHandle()]);
     return true;
   }


### PR DESCRIPTION
- The PR fixes the operand of null-aware operation warning below.

```console
/C:/Users/%EB%AF%BC%EC%84%B1/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/system_alert_window-0.5.0+1/lib/models/system_window_body.dart:19:49: Warning: Operand of null-aware operation '?.' has type 'EachRow' which excludes null.
 - 'EachRow' is from 'package:system_alert_window/models/system_window_body.dart' ('/C:/Users/%EB%AF%BC%EC%84%B1/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/system_alert_window-0.5.0+1/lib/models/system_window_body.dart').
          : List<dynamic>.from(rows!.map((x) => x?.getMap())),
                                                ^
/C:/Users/%EB%AF%BC%EC%84%B1/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/system_alert_window-0.5.0+1/lib/models/system_window_body.dart:41:52: Warning: Operand of null-aware operation '?.' has type 'EachColumn' which excludes null.
 - 'EachColumn' is from 'package:system_alert_window/models/system_window_body.dart' ('/C:/Users/%EB%AF%BC%EC%84%B1/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/system_alert_window-0.5.0+1/lib/models/system_window_body.dart').
          : List<dynamic>.from(columns!.map((x) => x?.getMap())),
```

- And this also fixes #60 caused from invalid typecasting.