### PR TITLE
81 ] Button call back not working

### DIFF
--- a/lib/system_alert_window.dart
+++ b/lib/system_alert_window.dart
@@ -50,7 +50,7 @@ class SystemAlertWindow {
   static Future<bool?> registerOnClickListener(OnClickListener callBackFunction) async {
     final callBackDispatcher = PluginUtilities.getCallbackHandle(callbackDispatcher)!;
     final callBack = PluginUtilities.getCallbackHandle(callBackFunction)!;
-    _channel.setMethodCallHandler((MethodCall call) {
+     _channel.setMethodCallHandler((MethodCall call) async {
       print("Got callback");
       switch (call.method) {
         case "callBack":
@@ -64,7 +64,7 @@ class SystemAlertWindow {
           }
       }
       return null;
-    } as Future<dynamic> Function(MethodCall)?);
+    });
     await _channel.invokeMethod("registerCallBackHandler", <dynamic>[callBackDispatcher.toRawHandle(), callBack.toRawHandle()]);
     return true;
   }


### PR DESCRIPTION
changed the  _channel.setMethodCallHandler method to handle `Unhandled Exception: type '(MethodCall) => Null' is not a subtype of type '((MethodCall) => Future)?' in type cast` error